### PR TITLE
店舗ページに地図を追加

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,6 @@ import { SpTop } from '@/components/pages/Sp/Top'
 import { Top } from '@/components/pages/Top'
 import { useWindowWidth } from '@/hooks/useWindowWidth'
 import { useState } from 'react'
-import { Map, StoreLocation } from '../components/organisms/Map';
 
 export default function Home() {
   const width = useWindowWidth()
@@ -18,24 +17,6 @@ export default function Home() {
     }
     return <SpTop setSearch={setSearch} setFocus={setFocus} />
   }
-
-  const storeLocations: StoreLocation[] = [
-    {
-      name: "店舗1",
-      location: { lat: -34.397, lng: 150.644 }
-    },
-    {
-      name: "店舗2",
-      location: { lat: -34.399, lng: 150.648 }
-    }
-  ];
-
-  return (
-    <div>
-      <h1>飲食店の地図</h1>
-      <Map storeLocations={storeLocations} />
-    </div>
-  );
 
   return <Top />
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,16 +21,13 @@ export default function Home() {
 
   const storeLocations: StoreLocation[] = [
     {
-      id: 1,
       name: "店舗1",
       location: { lat: -34.397, lng: 150.644 }
     },
     {
-      id: 2,
       name: "店舗2",
       location: { lat: -34.399, lng: 150.648 }
     }
-    // 他の店舗を追加
   ];
 
   return (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { SpTop } from '@/components/pages/Sp/Top'
 import { Top } from '@/components/pages/Top'
 import { useWindowWidth } from '@/hooks/useWindowWidth'
 import { useState } from 'react'
+import { Map, StoreLocation } from '../components/organisms/Map';
 
 export default function Home() {
   const width = useWindowWidth()
@@ -17,6 +18,27 @@ export default function Home() {
     }
     return <SpTop setSearch={setSearch} setFocus={setFocus} />
   }
+
+  const storeLocations: StoreLocation[] = [
+    {
+      id: 1,
+      name: "店舗1",
+      location: { lat: -34.397, lng: 150.644 }
+    },
+    {
+      id: 2,
+      name: "店舗2",
+      location: { lat: -34.399, lng: 150.648 }
+    }
+    // 他の店舗を追加
+  ];
+
+  return (
+    <div>
+      <h1>飲食店の地図</h1>
+      <Map storeLocations={storeLocations} />
+    </div>
+  );
 
   return <Top />
 }

--- a/components/organisms/Map/index.tsx
+++ b/components/organisms/Map/index.tsx
@@ -19,6 +19,7 @@ const MapContainer = styled.div`
   bottom: 0;
   right: 0;
   text-align: right;
+  z-index: 5;
 `
 
 interface MapProps {
@@ -32,6 +33,7 @@ export const Map: React.FC<MapProps> = ({ items }) => {
     googleMapsApiKey: `${process.env.NEXT_PUBLIC_API_KEY}`,
     libraries: ['geometry', 'drawing'],
   })
+  console.log(items)
   if (!isLoaded) return
   return (
     <MapContainer>
@@ -40,7 +42,7 @@ export const Map: React.FC<MapProps> = ({ items }) => {
         text={map ? '地図を非表示にする' : '地図を表示する'}
         onClick={() => setMap(!map)}
       ></Button>
-      {map && (
+      {map && items.length > 0 && (
         <GoogleMap
           mapContainerStyle={containerStyle}
           center={{ lat: items[0]?.location.lat, lng: items[0]?.location.lng }}

--- a/components/organisms/Map/index.tsx
+++ b/components/organisms/Map/index.tsx
@@ -1,0 +1,54 @@
+// components/Map.tsx
+import React from 'react'
+import {
+  GoogleMap,
+  InfoWindowF,
+  LoadScript,
+  MarkerF,
+} from '@react-google-maps/api'
+
+type Location = {
+  lat: number
+  lng: number
+}
+
+export interface StoreLocation {
+  id: number
+  name: string
+  location: Location
+}
+
+const containerStyle = {
+  width: '400px',
+  height: '400px',
+}
+
+interface MapProps {
+  storeLocations: StoreLocation[]
+}
+
+export const Map: React.FC<MapProps> = ({ storeLocations }) => {
+  return (
+    <LoadScript googleMapsApiKey={`${process.env.NEXT_PUBLIC_API_KEY}`}>
+      <GoogleMap
+        mapContainerStyle={containerStyle}
+        center={storeLocations[0].location}
+        zoom={15}
+      >
+        {storeLocations.map((storeLocation, index) => (
+          <MarkerF key={index} position={storeLocation.location} />
+        ))}
+        {storeLocations.map((storeLocation, index) => (
+          <InfoWindowF key={index}     position={{
+            lat: storeLocation.location.lat + 0.0015, // 緯度の値に小さな値を加える
+            lng: storeLocation.location.lng
+          }}>
+            <div>
+              <h2>{storeLocation.name}</h2>
+            </div>
+          </InfoWindowF>
+        ))}
+      </GoogleMap>
+    </LoadScript>
+  )
+}

--- a/components/organisms/Map/index.tsx
+++ b/components/organisms/Map/index.tsx
@@ -1,4 +1,3 @@
-// components/Map.tsx
 import React from 'react'
 import {
   GoogleMap,
@@ -13,7 +12,6 @@ type Location = {
 }
 
 export interface StoreLocation {
-  id: number
   name: string
   location: Location
 }
@@ -40,7 +38,7 @@ export const Map: React.FC<MapProps> = ({ storeLocations }) => {
         ))}
         {storeLocations.map((storeLocation, index) => (
           <InfoWindowF key={index}     position={{
-            lat: storeLocation.location.lat + 0.0015, // 緯度の値に小さな値を加える
+            lat: storeLocation.location.lat + 0.0015,
             lng: storeLocation.location.lng
           }}>
             <div>

--- a/components/organisms/Map/index.tsx
+++ b/components/organisms/Map/index.tsx
@@ -1,52 +1,68 @@
-import React from 'react'
+import React, { useState } from 'react'
 import {
   GoogleMap,
   InfoWindowF,
-  LoadScript,
   MarkerF,
+  useJsApiLoader,
 } from '@react-google-maps/api'
-
-type Location = {
-  lat: number
-  lng: number
-}
-
-export interface StoreLocation {
-  name: string
-  location: Location
-}
+import { StoreLocation } from '@/utils/type'
+import styled from 'styled-components'
+import { Button } from '@/components/atoms/Button'
 
 const containerStyle = {
-  width: '400px',
-  height: '400px',
+  width: '300px',
+  height: '300px',
 }
+
+const MapContainer = styled.div`
+  position: fixed;
+  bottom: 0;
+  right: 0;
+  text-align: right;
+`
 
 interface MapProps {
-  storeLocations: StoreLocation[]
+  items: StoreLocation[]
 }
 
-export const Map: React.FC<MapProps> = ({ storeLocations }) => {
+export const Map: React.FC<MapProps> = ({ items }) => {
+  const [map, setMap] = useState<boolean>(true)
+  const { isLoaded } = useJsApiLoader({
+    id: 'google-map-script',
+    googleMapsApiKey: `${process.env.NEXT_PUBLIC_API_KEY}`,
+    libraries: ['geometry', 'drawing'],
+  })
+  if (!isLoaded) return
   return (
-    <LoadScript googleMapsApiKey={`${process.env.NEXT_PUBLIC_API_KEY}`}>
-      <GoogleMap
-        mapContainerStyle={containerStyle}
-        center={storeLocations[0].location}
-        zoom={15}
-      >
-        {storeLocations.map((storeLocation, index) => (
-          <MarkerF key={index} position={storeLocation.location} />
-        ))}
-        {storeLocations.map((storeLocation, index) => (
-          <InfoWindowF key={index}     position={{
-            lat: storeLocation.location.lat + 0.0015,
-            lng: storeLocation.location.lng
-          }}>
-            <div>
-              <h2>{storeLocation.name}</h2>
-            </div>
-          </InfoWindowF>
-        ))}
-      </GoogleMap>
-    </LoadScript>
+    <MapContainer>
+      <Button
+        bgcolor="#FFA234"
+        text={map ? '地図を非表示にする' : '地図を表示する'}
+        onClick={() => setMap(!map)}
+      ></Button>
+      {map && (
+        <GoogleMap
+          mapContainerStyle={containerStyle}
+          center={{ lat: items[0]?.location.lat, lng: items[0]?.location.lng }}
+          zoom={15}
+        >
+          {items.map((item, index) => (
+            <MarkerF key={index} position={item.location}>
+              <InfoWindowF
+                key={index}
+                position={{
+                  lat: item.location.lat + 0.00005,
+                  lng: item.location.lng,
+                }}
+              >
+                <div>
+                  <h2>{item.store_name}</h2>
+                </div>
+              </InfoWindowF>
+            </MarkerF>
+          ))}
+        </GoogleMap>
+      )}
+    </MapContainer>
   )
 }

--- a/components/pages/StorePage/index.tsx
+++ b/components/pages/StorePage/index.tsx
@@ -9,6 +9,8 @@ import { ResponseType, Store } from '@/utils/type'
 import logo from '../../../public/blackLogo.png'
 import { useRouter } from 'next/navigation'
 import { genreList } from '@/utils/const'
+import { Map } from '@/components/organisms/Map'
+import { useExtractLocationData } from '@/hooks/useExtraLocationData'
 
 interface StorePageProps {
   items: ResponseType
@@ -64,6 +66,7 @@ export const StorePage: React.FC<StorePageProps> = ({
   searchParams,
 }) => {
   const router = useRouter()
+  const locationData = useExtractLocationData(items)
   return (
     <div>
       <LogoContainer>
@@ -78,6 +81,7 @@ export const StorePage: React.FC<StorePageProps> = ({
         />
       </LogoContainer>
       <Header searchParams={searchParams} />
+      <Map items={locationData} />
       <Container>
         <IconWrapper>
           <Tabelog>食べログ</Tabelog>

--- a/hooks/useExtraLocationData.ts
+++ b/hooks/useExtraLocationData.ts
@@ -1,0 +1,23 @@
+import { ResponseType, StoreLocation } from '@/utils/type'
+import { useEffect, useState } from 'react'
+
+export const useExtractLocationData = (response: ResponseType) => {
+  const [locations, setLocations] = useState<StoreLocation[]>([])
+
+  useEffect(() => {
+    const extractedData: StoreLocation[] = []
+
+    Object.values(response).forEach((genre) => {
+      genre.forEach((store) => {
+        extractedData.push({
+          store_name: store.store_name,
+          location: store.location,
+        })
+      })
+    })
+
+    setLocations(extractedData)
+  }, [response])
+
+  return locations
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.1",
+    "@react-google-maps/api": "^2.19.2",
     "@swc/core": "^1.3.88",
     "@testing-library/jest-dom": "^6.1.3",
     "@testing-library/react": "^14.0.0",

--- a/utils/type.ts
+++ b/utils/type.ts
@@ -5,10 +5,24 @@ export interface Store {
   lunch: string
   link: string
   google_rating: number
+  location: Location
+}
+
+export interface Location {
+  lat: number
+  lng: number
 }
 
 export interface ResponseType {
   [key: string]: Store[]
+}
+
+export interface StoreLocation {
+  store_name: string
+  location: {
+    lat: number
+    lng: number
+  }
 }
 
 export interface StoreParams {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1388,10 +1388,10 @@
   dependencies:
     fast-deep-equal "^3.1.3"
 
-"@googlemaps/markerclusterer@2.3.2":
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/@googlemaps/markerclusterer/-/markerclusterer-2.3.2.tgz#b311c26a0c0e8bb6325759ea690aef68c7150d8a"
-  integrity sha512-zb9OQP8XscZp2Npt1uQUYnGKu1miuq4DPP28JyDuFd6HV17HCEcjV9MtBi4muG/iVRXXvuHW9bRCnHbao9ITfw==
+"@googlemaps/markerclusterer@2.5.3":
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/@googlemaps/markerclusterer/-/markerclusterer-2.5.3.tgz#9f891ce7e8e161775f3a3e2c9f66956810284591"
+  integrity sha512-x7lX0R5yYOoiNectr10wLgCBasNcXFHiADIBdmn7jQllF2B5ENQw5XtZK+hIw4xnV0Df0xhN4LN98XqA5jaiOw==
   dependencies:
     fast-deep-equal "^3.1.3"
     supercluster "^8.0.1"
@@ -2119,15 +2119,15 @@
     "@babel/runtime" "^7.13.10"
 
 "@react-google-maps/api@^2.19.2":
-  version "2.19.2"
-  resolved "https://registry.yarnpkg.com/@react-google-maps/api/-/api-2.19.2.tgz#678dc1871fbab72cd46d338eed687a36bf556ab1"
-  integrity sha512-Vt57XWzCKfsUjKOmFUl2erVVfOePkPK5OigF/f+q7UuV/Nm9KDDy1PMFBx+wNahEqOd6a32BxfsykEhBnbU9wQ==
+  version "2.19.3"
+  resolved "https://registry.yarnpkg.com/@react-google-maps/api/-/api-2.19.3.tgz#6bb307c6e9d06344badd77facb6dc9eaac5b9b32"
+  integrity sha512-jiLqvuOt5lOowkLeq7d077AByTyJp+s6hZVlLhlq7SBacBD37aUNpXBz2OsazfeR6Aw4a+9RRhAEjEFvrR1f5A==
   dependencies:
     "@googlemaps/js-api-loader" "1.16.2"
-    "@googlemaps/markerclusterer" "2.3.2"
+    "@googlemaps/markerclusterer" "2.5.3"
     "@react-google-maps/infobox" "2.19.2"
     "@react-google-maps/marker-clusterer" "2.19.2"
-    "@types/google.maps" "3.53.5"
+    "@types/google.maps" "3.55.2"
     invariant "2.2.4"
 
 "@react-google-maps/infobox@2.19.2":
@@ -3275,10 +3275,10 @@
   resolved "https://registry.yarnpkg.com/@types/find-cache-dir/-/find-cache-dir-3.2.1.tgz#7b959a4b9643a1e6a1a5fe49032693cc36773501"
   integrity sha512-frsJrz2t/CeGifcu/6uRo4b+SzAwT4NYCVPu1GN8IB9XTzrpPkGuV0tmh9mN+/L0PklAlsC3u5Fxt0ju00LXIw==
 
-"@types/google.maps@3.53.5":
-  version "3.53.5"
-  resolved "https://registry.yarnpkg.com/@types/google.maps/-/google.maps-3.53.5.tgz#0f3010ab4eabe46721f3604462196975b640aab9"
-  integrity sha512-HoRq4Te8J6krH7hj+TfdYepqegoKZCj3kkaK5gf+ySFSHLvyqYkDvkrtbcVJXQ6QBphQ0h1TF7p4J6sOh4r/zg==
+"@types/google.maps@3.55.2":
+  version "3.55.2"
+  resolved "https://registry.yarnpkg.com/@types/google.maps/-/google.maps-3.55.2.tgz#6e5a1c257aeda3861a919a56fb9f369468e79e15"
+  integrity sha512-JcTwzkxskR8DN/nnX96Pie3gGN3WHiPpuxzuQ9z3516o1bB243d8w8DHUJ8BohuzoT1o3HUFta2ns/mkZC8KRw==
 
 "@types/graceful-fs@^4.1.3":
   version "4.1.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1381,6 +1381,21 @@
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.1.4.tgz#19654d1026cc410975d46445180e70a5089b3e7d"
   integrity sha512-qprfWkn82Iw821mcKofJ5Pk9wgioHicxcQMxx+5zt5GSKoqdWvgG5AxVmpmUUjzTLPVSH5auBrhI93Deayn/DA==
 
+"@googlemaps/js-api-loader@1.16.2":
+  version "1.16.2"
+  resolved "https://registry.yarnpkg.com/@googlemaps/js-api-loader/-/js-api-loader-1.16.2.tgz#3fe748e21243f8e8322c677a5525c569ae9cdbe9"
+  integrity sha512-psGw5u0QM6humao48Hn4lrChOM2/rA43ZCm3tKK9qQsEj1/VzqkCqnvGfEOshDbBQflydfaRovbKwZMF4AyqbA==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+
+"@googlemaps/markerclusterer@2.3.2":
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@googlemaps/markerclusterer/-/markerclusterer-2.3.2.tgz#b311c26a0c0e8bb6325759ea690aef68c7150d8a"
+  integrity sha512-zb9OQP8XscZp2Npt1uQUYnGKu1miuq4DPP28JyDuFd6HV17HCEcjV9MtBi4muG/iVRXXvuHW9bRCnHbao9ITfw==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    supercluster "^8.0.1"
+
 "@hookform/resolvers@^3.3.1":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-3.3.1.tgz#b7cbfe767434f52cba6b99b0a9a0b73eb8895188"
@@ -2102,6 +2117,28 @@
   integrity sha512-fyrgCaedtvMg9NK3en0pnOYJdtfwxUcNolezkNPUsoX57X8oQk+NkqcvzHXD2uKNij6GXmWU9NDru2IWjrO4BQ==
   dependencies:
     "@babel/runtime" "^7.13.10"
+
+"@react-google-maps/api@^2.19.2":
+  version "2.19.2"
+  resolved "https://registry.yarnpkg.com/@react-google-maps/api/-/api-2.19.2.tgz#678dc1871fbab72cd46d338eed687a36bf556ab1"
+  integrity sha512-Vt57XWzCKfsUjKOmFUl2erVVfOePkPK5OigF/f+q7UuV/Nm9KDDy1PMFBx+wNahEqOd6a32BxfsykEhBnbU9wQ==
+  dependencies:
+    "@googlemaps/js-api-loader" "1.16.2"
+    "@googlemaps/markerclusterer" "2.3.2"
+    "@react-google-maps/infobox" "2.19.2"
+    "@react-google-maps/marker-clusterer" "2.19.2"
+    "@types/google.maps" "3.53.5"
+    invariant "2.2.4"
+
+"@react-google-maps/infobox@2.19.2":
+  version "2.19.2"
+  resolved "https://registry.yarnpkg.com/@react-google-maps/infobox/-/infobox-2.19.2.tgz#b6bda962a4fa1074fdd3dfd63bc4c7d68b1dd745"
+  integrity sha512-6wvBqeJsQ/eFSvoxg+9VoncQvNoVCdmxzxRpLvmjPD+nNC6mHM0vJH1xSqaKijkMrfLJT0nfkTGpovrF896jwg==
+
+"@react-google-maps/marker-clusterer@2.19.2":
+  version "2.19.2"
+  resolved "https://registry.yarnpkg.com/@react-google-maps/marker-clusterer/-/marker-clusterer-2.19.2.tgz#24d9fb9aa555bb063ba5fe82f80fcd7d48662184"
+  integrity sha512-x9ibmsP0ZVqzyCo1Pitbw+4b6iEXRw/r1TCy3vOUR3eKrzWLnHYZMR325BkZW2r8fnuWE/V3Fp4QZOP9qYORCw==
 
 "@rushstack/eslint-patch@^1.3.3":
   version "1.5.1"
@@ -3237,6 +3274,11 @@
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@types/find-cache-dir/-/find-cache-dir-3.2.1.tgz#7b959a4b9643a1e6a1a5fe49032693cc36773501"
   integrity sha512-frsJrz2t/CeGifcu/6uRo4b+SzAwT4NYCVPu1GN8IB9XTzrpPkGuV0tmh9mN+/L0PklAlsC3u5Fxt0ju00LXIw==
+
+"@types/google.maps@3.53.5":
+  version "3.53.5"
+  resolved "https://registry.yarnpkg.com/@types/google.maps/-/google.maps-3.53.5.tgz#0f3010ab4eabe46721f3604462196975b640aab9"
+  integrity sha512-HoRq4Te8J6krH7hj+TfdYepqegoKZCj3kkaK5gf+ySFSHLvyqYkDvkrtbcVJXQ6QBphQ0h1TF7p4J6sOh4r/zg==
 
 "@types/graceful-fs@^4.1.3":
   version "4.1.7"
@@ -6956,7 +6998,7 @@ internal-slot@^1.0.4, internal-slot@^1.0.5:
     has "^1.0.3"
     side-channel "^1.0.4"
 
-invariant@^2.2.4:
+invariant@2.2.4, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -7902,6 +7944,11 @@ jsonfile@^6.0.1:
     array.prototype.flat "^1.3.1"
     object.assign "^4.1.4"
     object.values "^1.1.6"
+
+kdbush@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/kdbush/-/kdbush-4.0.2.tgz#2f7b7246328b4657dd122b6c7f025fbc2c868e39"
+  integrity sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==
 
 keyv@^4.5.3:
   version "4.5.3"
@@ -10307,6 +10354,13 @@ sucrase@^3.32.0:
     pirates "^4.0.1"
     ts-interface-checker "^0.1.9"
 
+supercluster@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/supercluster/-/supercluster-8.0.1.tgz#9946ba123538e9e9ab15de472531f604e7372df5"
+  integrity sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==
+  dependencies:
+    kdbush "^4.0.2"
+
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
@@ -11147,6 +11201,7 @@ wordwrap@^1.0.0:
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  name wrap-ansi-cjs
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
### 概要
これまでは出力された店舗の場所は別途GoogleMapなどで検索をかける必要があったがこのプロダクト内でgoogleMapの地図を表示するようにした。

### 技術的変更点
GoogleMapsAPIを使って地図を表示。
https://developers.google.com/maps/?hl=ja

### スクショ
<img width="1470" alt="スクリーンショット 2024-03-26 17 30 55" src="https://github.com/ponta10/dishfinder/assets/94046278/1fa236aa-869e-426e-9395-49088ba1c711">


### チェックポイント

- [x] 正常に地図が表示されているか
- [x] 適切な縮尺で地図が表示できているか
- [x] 地図の表示・非表示の切り替えができるか